### PR TITLE
Add instagram card formats

### DIFF
--- a/index.html
+++ b/index.html
@@ -45,6 +45,15 @@
                         <span>Fortissimo</span>
                     </div>
                 </div>
+                <div class="control-group">
+                    <label for="format-selector">Formato do Card</label>
+                    <select id="format-selector">
+                        <option value="400x400">Quadrado 1:1</option>
+                        <option value="400x500">Retrato 4:5</option>
+                        <option value="400x210">Paisagem 1.91:1</option>
+                        <option value="400x711">Story 9:16</option>
+                    </select>
+                </div>
             </div>
 
             <div class="global-control">

--- a/src/layout/adaptiveLayoutComposer.js
+++ b/src/layout/adaptiveLayoutComposer.js
@@ -21,7 +21,7 @@ export class TextOptimizedStrategy extends LayoutStrategy {
     }
     
     async compose(blocks, context) {
-        const composer = new LayoutComposer(blocks, context.config.typographicRatio);
+        const composer = new LayoutComposer(blocks, context.config.typographicRatio, context.width);
         return composer.findBestCandidate();
     }
 }
@@ -32,7 +32,7 @@ export class MixedContentStrategy extends LayoutStrategy {
     }
     
     async compose(blocks, context) {
-        const composer = new LayoutComposer(blocks, context.config.typographicRatio);
+        const composer = new LayoutComposer(blocks, context.config.typographicRatio, context.width);
         const result = await composer.findBestCandidate();
         
         if (result.isSuccess) {
@@ -51,7 +51,7 @@ export class BalancedStrategy extends LayoutStrategy {
     }
     
     async compose(blocks, context) {
-        const composer = new LayoutComposer(blocks, context.config.typographicRatio);
+        const composer = new LayoutComposer(blocks, context.config.typographicRatio, context.width);
         return composer.findBestCandidate();
     }
 }
@@ -73,20 +73,23 @@ export class AdaptiveLayoutComposer {
                 return Result.failure(new LayoutError('Nenhum bloco fornecido'));
             }
             
+            const width = (config.cardWidth || 400) - 64;
+
             const analysis = this.contentAnalyzer.analyze(blocks);
             const strategy = this.selectOptimalStrategy(analysis, config);
             const blocksWithHierarchy = this._calculateHierarchy(blocks, config);
-            
+
             const candidateResult = await strategy.compose(blocksWithHierarchy, {
                 config,
-                analysis
+                analysis,
+                width
             });
             
             if (candidateResult.isFailure) {
                 return candidateResult;
             }
             
-            const optimizer = new LayoutOptimizer(blocksWithHierarchy, candidateResult.value);
+            const optimizer = new LayoutOptimizer(blocksWithHierarchy, candidateResult.value, width);
             const finalResult = await optimizer.optimizeZoom();
             
             if (finalResult.isSuccess) {

--- a/src/layout/layoutComposer.js
+++ b/src/layout/layoutComposer.js
@@ -2,9 +2,10 @@ import { Result } from '../utils/result.js';
 import { CardCreatorError, LayoutError, ValidationError } from '../utils/customErrors.js';
 
 export class LayoutComposer {
-            constructor(blocks, ratio) {
+            constructor(blocks, ratio, width) {
                 this.blocks = [...blocks].sort((a, b) => b.hierarchy - a.hierarchy);
                 this.ratio = ratio;
+                this.width = width || 336;
             }
             
             async findBestCandidate() {
@@ -58,7 +59,7 @@ export class LayoutComposer {
                 return new Promise((resolve, reject) => {
                     try {
                         const testContainer = document.createElement('div');
-                        testContainer.style.cssText = 'position: absolute; visibility: hidden; width: 336px;';
+                        testContainer.style.cssText = `position: absolute; visibility: hidden; width: ${this.width}px;`;
                         document.body.appendChild(testContainer);
                         
                         const lowestHierarchy = Math.min(...this.blocks.map(b => b.hierarchy));
@@ -131,7 +132,7 @@ export class LayoutComposer {
                 }
                 totalBadness += lineCountPenalty;
                 
-                const requiredZoom = 336 / totalBlueprintHeight;
+                const requiredZoom = this.width / totalBlueprintHeight;
                 if (requiredZoom < 0.9) {
                     totalBadness += Math.pow(1 - requiredZoom, 2) * 50000;
                 }

--- a/src/layout/layoutOptimizer.js
+++ b/src/layout/layoutOptimizer.js
@@ -2,9 +2,10 @@ import { Result } from '../utils/result.js';
 import { CardCreatorError, LayoutError, ValidationError } from '../utils/customErrors.js';
 
 export class LayoutOptimizer {
-            constructor(blocks, layout) {
+            constructor(blocks, layout, width) {
                 this.blocks = blocks;
                 this.layout = layout;
+                this.width = width || 336;
             }
             
             async optimizeZoom() {
@@ -28,6 +29,7 @@ export class LayoutOptimizer {
                     return Result.success({
                         ...this.layout,
                         zoom: bestZoom,
+                        width: this.width,
                         blocks: this.blocks
                     });
                     
@@ -42,7 +44,7 @@ export class LayoutOptimizer {
                 return new Promise((resolve, reject) => {
                     try {
                         const testContainer = document.createElement('div');
-                        testContainer.style.cssText = 'position: absolute; visibility: hidden; width: 336px;';
+                        testContainer.style.cssText = `position: absolute; visibility: hidden; width: ${this.width}px;`;
                         document.body.appendChild(testContainer);
                         
                         const lowestHierarchy = Math.min(...this.blocks.map(b => b.hierarchy));
@@ -68,7 +70,7 @@ export class LayoutOptimizer {
                             totalHeight += el.offsetHeight;
                         }
                         
-                        const fits = totalHeight + totalGapHeight <= 336;
+                        const fits = totalHeight + totalGapHeight <= this.width;
                         document.body.removeChild(testContainer);
                         resolve(fits);
                         

--- a/src/renderer/enhancedLayoutRenderer.js
+++ b/src/renderer/enhancedLayoutRenderer.js
@@ -44,7 +44,7 @@ export class EnhancedLayoutRenderer {
                                 fontSize: finalSize,
                                 lineHeight: layout.lineHeight,
                                 zoom: layout.zoom,
-                                width: 336
+                                width: layout.width || 336
                             };
                             
                             const element = plugin.render(block, context);

--- a/src/state/enhancedCardState.js
+++ b/src/state/enhancedCardState.js
@@ -32,7 +32,9 @@ export class EnhancedCardState {
                 
                 this.config$ = new SimpleObservable({
                     globalContrast: 3,
-                    typographicRatio: 1.250
+                    typographicRatio: 1.250,
+                    cardWidth: 400,
+                    cardHeight: 400
                 });
                 
                 this.layout$ = new SimpleObservable(null);
@@ -201,6 +203,10 @@ export class EnhancedCardState {
                     
                     if (newConfig.typographicRatio < 1.1 || newConfig.typographicRatio > 2.0) {
                         throw new ValidationError('Ratio tipográfico deve estar entre 1.1 e 2.0');
+                    }
+
+                    if (newConfig.cardWidth < 100 || newConfig.cardHeight < 100) {
+                        throw new ValidationError('Dimensões do card devem ser maiores que 100px');
                     }
                     
                     this.config$.value = newConfig;

--- a/src/ui/enhancedUIController.js
+++ b/src/ui/enhancedUIController.js
@@ -25,6 +25,7 @@ export class EnhancedUIController {
                 
                 const scaleSlider = document.getElementById('scale-slider');
                 const contrastSlider = document.getElementById('contrast-slider');
+                const formatSelector = document.getElementById('format-selector');
                 
                 if (scaleSlider) {
                     scaleSlider.addEventListener('input', (e) => this._handleScaleChange(e));
@@ -32,6 +33,10 @@ export class EnhancedUIController {
                 
                 if (contrastSlider) {
                     contrastSlider.addEventListener('input', (e) => this._handleContrastChange(e));
+                }
+
+                if (formatSelector) {
+                    formatSelector.addEventListener('change', (e) => this._handleFormatChange(e));
                 }
                 
                 const controlsPanel = document.getElementById('controls-panel');
@@ -74,6 +79,8 @@ export class EnhancedUIController {
             _renderInitialUI() {
                 this._renderBlockControls(this.state.blocks$.value);
                 this._updateConfigUI(this.state.config$.value);
+                document.documentElement.style.setProperty('--card-width', `${this.state.config$.value.cardWidth}px`);
+                document.documentElement.style.setProperty('--card-height', `${this.state.config$.value.cardHeight}px`);
             }
             
             _renderPluginSelector() {
@@ -134,6 +141,15 @@ export class EnhancedUIController {
             _handleContrastChange(event) {
                 const contrast = parseInt(event.target.value);
                 this.state.updateConfig({ globalContrast: contrast });
+            }
+
+            _handleFormatChange(event) {
+                const [w, h] = event.target.value.split('x').map(v => parseInt(v));
+                if (w && h) {
+                    document.documentElement.style.setProperty('--card-width', `${w}px`);
+                    document.documentElement.style.setProperty('--card-height', `${h}px`);
+                    this.state.updateConfig({ cardWidth: w, cardHeight: h });
+                }
             }
             
             _handleBlockInput(event) {
@@ -242,6 +258,7 @@ export class EnhancedUIController {
             _updateConfigUI(config) {
                 const contrastSlider = document.getElementById('contrast-slider');
                 const scaleSlider = document.getElementById('scale-slider');
+                const formatSelector = document.getElementById('format-selector');
                 
                 if (contrastSlider) {
                     contrastSlider.value = config.globalContrast;
@@ -255,6 +272,10 @@ export class EnhancedUIController {
                 
                 if (scaleSlider) {
                     scaleSlider.value = validScaleIndex + 1;
+                }
+
+                if (formatSelector) {
+                    formatSelector.value = `${config.cardWidth}x${config.cardHeight}`;
                 }
                 
                 const scaleLabel = document.getElementById('scale-label');

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -5,3 +5,11 @@ export const SCALE_OPTIONS = [
     { name: "Impactante", value: 1.500 },
     { name: "Dinâmica", value: 1.618 }
 ];
+
+// Formatos padrão de cartão para Instagram (base 400px de largura)
+export const CARD_FORMATS = [
+    { name: 'Quadrado 1:1', width: 400, height: 400 },
+    { name: 'Retrato 4:5', width: 400, height: 500 },
+    { name: 'Paisagem 1.91:1', width: 400, height: 210 },
+    { name: 'Story 9:16', width: 400, height: 711 }
+];


### PR DESCRIPTION
## Summary
- add Instagram card format definitions
- support selecting card format in the UI
- propagate card width to layout engine and renderer
- validate card dimensions in card state

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688d149cd96883218d11d0afc12017cf