### PR TITLE
Fix CSS to prevent text breaking mid-word

### DIFF
--- a/card-creator-com-marcacoes.html
+++ b/card-creator-com-marcacoes.html
@@ -267,8 +267,8 @@
         
         .card-element {
             text-align: center;
-            overflow-wrap: break-word;
-            word-break: break-word;
+            overflow-wrap: normal;
+            word-break: normal;
             max-width: 100%;
         }
         

--- a/styles/main.css
+++ b/styles/main.css
@@ -261,8 +261,8 @@
         
         .card-element {
             text-align: center;
-            overflow-wrap: break-word;
-            word-break: break-word;
+            overflow-wrap: normal;
+            word-break: normal;
             max-width: 100%;
         }
         


### PR DESCRIPTION
## Summary
- update `.card-element` styling in main CSS
- keep `card-creator-com-marcacoes.html` example consistent

## Testing
- `grep -n word-break -r`


------
https://chatgpt.com/codex/tasks/task_e_688d28583c688321b3ff6f31c8a63dfc